### PR TITLE
Player keyboard and screenreader support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test-ci": "echo 'tests not implemented'"
   },
   "dependencies": {
-    "materia-widget-development-kit": "2.4.2"
+    "materia-widget-development-kit": "2.5.2"
   },
   "license": "AGPL-3.0",
   "description": "Sequencer is about teaching ordered events and sequences. Items are presented to students in a random order for them to re-arrange. Designed for use in Materia.",

--- a/src/install.yaml
+++ b/src/install.yaml
@@ -21,6 +21,8 @@ score:
   is_scorable: Yes
   score_module: Sequencer
 meta_data:
+  accessibility_keyboard: Full
+  accessibility_reader: Full
   features:
     - Customizable
     - Scorable

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -291,8 +291,6 @@ Namespace('Sequencer').Engine = do ->
 					_sequence.splice(i,1)
 					_tilesInSequence--
 
-					console.log _curterm
-
 					_curterm.style.transform =
 					_curterm.style.msTransform =
 					_curterm.style.webkitTransform = "translate(#{_tiles[_curterm.id].xpos}px,#{_tiles[_curterm.id].ypos}px) rotate(#{_tiles[_curterm.id].angle}deg)"

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -326,9 +326,13 @@ Namespace('Sequencer').Engine = do ->
 				if (i = _sequence.indexOf(~~_curterm.id)) != -1 and i != 0
 					[_sequence[i - 1], _sequence[i]] = [_sequence[i], _sequence[i - 1]]
 
+					_assistiveStatusUpdate(_tiles[_curterm.id].name + ' moved to position   ' + i + ' of ' + _tilesInSequence)
+
 			when 40 # down arrow - sort downwards
 				if (i = _sequence.indexOf(~~_curterm.id)) != -1 and i != _sequence.length - 1
 					[_sequence[i + 1], _sequence[i]] = [_sequence[i], _sequence[i + 1]]
+
+					_assistiveStatusUpdate(_tiles[_curterm.id].name + ' moved to position   ' + (i + 2) + ' of ' + _tilesInSequence)
 
 
 		# Remove the empty slots

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -543,7 +543,6 @@ Namespace('Sequencer').Engine = do ->
 				$('#'+tile.id).children('.clue').remove()
 				$('#'+tile.id).attr('aria-label', _tiles[tile.id].name)
 			else $('#'+tile.id).attr('aria-label', _tiles[tile.id].name + '. This tile has a clue, press enter to review it.')
-			# else $('#'+tile.id).prop('boop', 'bleh')
 
 	# Show the clue from the id of the tile clicked
 	_revealClue = (id) ->
@@ -628,8 +627,6 @@ Namespace('Sequencer').Engine = do ->
 		# Restore Free Attempts counter
 		else
 			_freeAttempts++
-
-		# _assistiveStatusUpdate('You sorted ' + results + ' of ' + _numTiles + ' correctly.')
 
 		# Update the score based on the new results
 		score = Math.round((results / _numTiles) * 100)
@@ -821,7 +818,6 @@ Namespace('Sequencer').Engine = do ->
 
 	_assistiveStatusUpdate = (status) ->
 		$('.ariaLiveStatus').html status
-		# $('.ariaLiveAlert').html _tilesInSequence + ' of ' + _numTiles + ' sorted.'
 
 	_sendScores = () ->
 		answer = 0

--- a/src/player.html
+++ b/src/player.html
@@ -49,7 +49,11 @@
 			<p>You have <span class="demoDeduction"><%= freeAttempts %> guesses</span>.</p>
 			<p>Your highest score will be saved.</p>
 		</div>
-		<button tabindex=0 class="demoButton">Play Sequencer</button>
+		<button tabindex=0
+			class="demoButton"
+			aria-label="<%= introInstructions %>">
+			Play Sequencer
+		</button>
 	</div>
 </div>
 </script>
@@ -62,7 +66,8 @@
 		</header>
 		<button id="keyboard-instructions"
 			class="big-button enabled"
-			tabindex=0>
+			tabindex=0
+			aria-label="<%= keyboardInstructions %>">
 			Keyboard Instructions
 		</button>
 		<div id="dragContainer" role="list">
@@ -95,7 +100,8 @@
 		</div>
 		<button id="wraparound"
 			class="visible-on-focus big-button nondraggable"
-			tabindex=0>
+			tabindex=0
+			aria-label='Press Space or Enter to select the first unsorted tile.'>
 			Select First Unsorted Item
 		</button>
 		<footer id="score-area">

--- a/src/player.html
+++ b/src/player.html
@@ -27,12 +27,12 @@
 		<section id="widgetTitle"><%= title %></section>
 		<hr>
 	</header>
-	<div id="dragContainer">
+	<div id="dragContainer" role="list">
 		<!-- tiles -->
 		<% for(var t in tiles) { var tile = tiles[t]; %>
-			<div class="tile" data-id="<%= tile.id %>" id="<%= tile.id %>" tabindex="<%= parseInt(t, 10)+1+(tiles.length) %>">
+			<div class="tile" data-id="<%= tile.id %>" id="<%= tile.id %>" tabindex="<%= parseInt(t, 10)+1+(tiles.length) %>" role="listitem">
 			<%= tile.name %>
-			<div class="clue" data-id="<%= tile.id %>"></div>
+				<button class="clue" data-id="<%= tile.id %>" tabindex="-1"></button>
 			</div>
 		<% } %>
 		<div id="tileFiller"></div>
@@ -45,7 +45,7 @@
 		<div id="orderInstructions">Drag and organize tiles here</div>
 	</section>
 	<div id="submitHolder" class="nondraggable">
-		<div id="submit" class="nondraggable">Submit Sequence</div>
+		<button id="submit" class="nondraggable" disabled="true">Submit Sequence</button>
 	</div>
 	<footer id="score-area">
 		<h4 id="score-text">Score: <span id="score"><%= score %></span></h4>
@@ -57,7 +57,7 @@
 <!-- clues -->
 <script type="text/template" id="tile-clue-window"><div id="clueHeader">
 		<h3 class="clueTitle"><%= name %></h3>
-		<aside class="tile-clue-text">
+		<aside role="definition" class="tile-clue-text" aria-live="polite">
 			<p class="clueDescription"><%= clue %></p>
 		</aside>
 	</div>
@@ -108,7 +108,7 @@
 				<p>You have <span class="demoDeduction"><%= freeAttempts %> guesses</span>.</p>
 				<p>Your highest score will be saved.</p>
 			</div>
-			<div class="demoButton">Play Sequencer</div>
+			<button class="demoButton">Play Sequencer</button>
 		</div>
 	</div>
 </script>
@@ -169,8 +169,8 @@
 			<!--<span id="bestScoreMessage">Best score: <span class="circle" id="bestcircle"><%= penalty %></span></span>-->
 			<div id="correctMessage">Great Job!</div>
 			<div id="allAttemptsMessage">You are out of guesses.</div>
-			<div id="resultsButton" class="resultsButton"></div>
-			<div id="submitScoreButton"></div>
+			<button id="resultsButton" class="resultsButton"></button>
+			<button id="submitScoreButton"></button>
 		</div>
 	</section>
 </script>
@@ -179,9 +179,11 @@
 	<p>
 		Are you sure you want to stop with your best score of <span class="bestscore bold"></span>?
 	</p>
-	<div id="cancelBestScoreButton" class="resultsButton arial">No, keep trying</div>
-	<div id="confirmBestScoreButton" class="resultsButton arial">Yes, finish with <span class="bestscore"></span>.</div>
+	<button id="cancelBestScoreButton" class="resultsButton" tabindex="-1">No, keep trying</button>
+	<button id="confirmBestScoreButton" class="resultsButton" tabindex="-1">Yes, finish with <span class="bestscore"></span>.</button>
 </div>
+
+<div role="status" class="ariaLiveStatus" aria-live="polite"></div>
 
 <!-- INITIALIZE -->
 	<script>

--- a/src/player.html
+++ b/src/player.html
@@ -87,11 +87,14 @@
 			<div id="orderInstructions">Drag and organize tiles here</div>
 		</section>
 		<div id="submitHolder" class="nondraggable">
-			<button id="submit" class="big-button nondraggable" disabled="true">Submit Sequence</button>
+			<button id="submit"
+				class="big-button nondraggable"
+				tabindex=0>
+				Submit Sequence
+			</button>
 		</div>
 		<button id="wraparound"
 			class="visible-on-focus big-button nondraggable"
-			role="button"
 			tabindex=0>
 			Select First Unsorted Item
 		</button>
@@ -192,6 +195,33 @@
 		</div>
 	</section>
 </script>
+
+<div id="keyboard-instructions-window">
+	<h3>Keyboard Instructions</h3>
+	<p>
+		Use the <strong>Tab</strong> key to navigate through the terms from top to bottom, left to right.
+	</p>
+	<p>
+		Hold the <strong>Shift</strong> key when pressing the <strong>Tab</strong> key to navigate in reverse.
+	</p>
+	<p>
+		You will reach the sequenced terms after navigating through all of the unsorted terms.
+	</p>
+	<p>
+		Press the <strong>Right Arrow</strong> key when an unsorted term is selected to move it to the end of the sequence.
+	</p>
+	<p>
+		Press the <strong>Left Arrow</strong> key when a sequenced term is selected to remove it from the sequence.
+	</p>
+	<p>
+		Press the <strong>Up Arrow</strong> or <strong>Down Arrow</strong> keys when a sequenced term is selected to move it up or down in the sequence.
+	</p>
+	<button id="keyboard-close"
+		class="big-button enabled"
+		tabindex=0>
+		Close Keyboard Instructions
+	</button>
+</div>
 
 <div class="confirmDialog" inert="true">
 	<p>

--- a/src/player.html
+++ b/src/player.html
@@ -30,19 +30,21 @@
 		<h4>Put em in order</h4>
 	</div>
 	<div id="demoArea">
-		<div id="demoTitle"><%= demoTitle %></div>
-		<div id="demoFooter"></div>
-		<div class="demoTile move" id="dt1">1</div>
-		<div class="demoTile move" id="dt2">2</div>
-		<div class="demoTile move" id="dt3">3</div>
-		<div id="demoTileSection"></div>
-		<div id="demoOrderArea"></div>
-		<div id="demoNumberBar"></div>
-		<div id="demoSubmitButton" class="hover">Submit</div>
-		<div id="demoMouse"><img src="assets/cursor.svg"></div>
-		<div id="demoFinish" class="show">Score:
-			<div id="demoScore">100%</div>
-		</div>
+		<section id='demo-animation' aria-hidden="true">
+			<div id="demoTitle"><%= demoTitle %></div>
+			<div id="demoFooter"></div>
+			<div class="demoTile move" id="dt1">1</div>
+			<div class="demoTile move" id="dt2">2</div>
+			<div class="demoTile move" id="dt3">3</div>
+			<div id="demoTileSection"></div>
+			<div id="demoOrderArea"></div>
+			<div id="demoNumberBar"></div>
+			<div id="demoSubmitButton" class="hover">Submit</div>
+			<div id="demoMouse"><img src="assets/cursor.svg"></div>
+			<div id="demoFinish" class="show">Score:
+				<div id="demoScore">100%</div>
+			</div>
+		</section>
 		<div id="playInstructions">
 			<h3>How to play:</h3>
 			<p>Order the tiles correctly in the sequence list.</p>
@@ -146,7 +148,7 @@
 			<h3>Sequencer!</h3>
 			<h4>Put "em in order</h4>
 		</div>
-		<div id="resultsInner">
+		<div id="resultsInner" aria-hidden="true">
 			<h5>You have</h5>
 			<div id="flipNumberContainer">
 				<div id="rightDigit">
@@ -192,12 +194,14 @@
 			</div>
 		</div>
 		<div id="resultsBox">
-			<span id="lostPointsMessage">This score: <span class="circle" id="circle"><%= penalty %></span></span>
+			<span id="lostPointsMessage" aria-hidden="true">
+				This score: <span class="circle" id="circle"><%= penalty %></span>
+			</span>
 			<!--<span id="bestScoreMessage">Best score: <span class="circle" id="bestcircle"><%= penalty %></span></span>-->
-			<div id="correctMessage">Great Job!</div>
-			<div id="allAttemptsMessage">You are out of guesses.</div>
-			<button id="resultsButton" class="resultsButton"></button>
-			<button id="submitScoreButton"></button>
+			<div id="correctMessage" aria-hidden="true">Great Job!</div>
+			<div id="allAttemptsMessage" aria-hidden="true">You are out of guesses.</div>
+			<button id="resultsButton" class="resultsButton" aria-label=''></button>
+			<button id="submitScoreButton" aria-label=''></button>
 		</div>
 	</section>
 </script>

--- a/src/player.html
+++ b/src/player.html
@@ -21,37 +21,86 @@
 
 <body>
 <div class="fade active"></div>
-<script type="text/template" id="t-board"><div class="board">
-	<header>
-		<h3>Sequence:</h3>
-		<section id="widgetTitle"><%= title %></section>
-		<hr>
-	</header>
-	<div id="dragContainer" role="list">
-		<!-- tiles -->
-		<% for(var t in tiles) { var tile = tiles[t]; %>
-			<div class="tile" data-id="<%= tile.id %>" id="<%= tile.id %>" tabindex="<%= parseInt(t, 10)+1+(tiles.length) %>" role="listitem">
-			<%= tile.name %>
-				<button class="clue" data-id="<%= tile.id %>" tabindex="-1"></button>
-			</div>
-		<% } %>
-		<div id="tileFiller"></div>
+
+<!-- The child container element has to be inline. For some reason putting it on the next line breaks everything. -->
+<!-- message window (Tutorial) -->
+<script type="text/template" id="demo-window"><div id="demo">
+	<div id="popupWindowHeader">
+		<h3>Sequencer!</h3>
+		<h4>Put em in order</h4>
 	</div>
-	<section id="tileSection"></section>
-	<aside id="numberBar" class="nondraggable">
-		<div class="numbers">1</div>
-	</aside>
-	<section id="orderArea">
-		<div id="orderInstructions">Drag and organize tiles here</div>
-	</section>
-	<div id="submitHolder" class="nondraggable">
-		<button id="submit" class="nondraggable" disabled="true">Submit Sequence</button>
+	<div id="demoArea">
+		<div id="demoTitle"><%= demoTitle %></div>
+		<div id="demoFooter"></div>
+		<div class="demoTile move" id="dt1">1</div>
+		<div class="demoTile move" id="dt2">2</div>
+		<div class="demoTile move" id="dt3">3</div>
+		<div id="demoTileSection"></div>
+		<div id="demoOrderArea"></div>
+		<div id="demoNumberBar"></div>
+		<div id="demoSubmitButton" class="hover">Submit</div>
+		<div id="demoMouse"><img src="assets/cursor.svg"></div>
+		<div id="demoFinish" class="show">Score:
+			<div id="demoScore">100%</div>
+		</div>
+		<div id="playInstructions">
+			<h3>How to play:</h3>
+			<p>Order the tiles correctly in the sequence list.</p>
+			<p>You have <span class="demoDeduction"><%= freeAttempts %> guesses</span>.</p>
+			<p>Your highest score will be saved.</p>
+		</div>
+		<button tabindex=0 class="demoButton">Play Sequencer</button>
 	</div>
-	<footer id="score-area">
-		<h4 id="score-text">Score: <span id="score"><%= score %></span></h4>
-		<h5><span id="practiceMode-info">(Practice Mode)</span></h5>
-		<h5><span id="attempts-info">(<span id="attemptsLeft"><%= freeAttempts %></span> guesses left)</span></h5>
-	</footer>
+</div>
+</script>
+
+<script type="text/template" id="t-board"><div class="board" inert="true">
+		<header>
+			<h3>Sequence:</h3>
+			<section id="widgetTitle"><%= title %></section>
+			<hr>
+		</header>
+		<button id="keyboard-instructions"
+			class="big-button enabled"
+			tabindex=0>
+			Keyboard Instructions
+		</button>
+		<div id="dragContainer" role="list">
+			<!-- tiles -->
+			<% for(var t in tiles) { var tile = tiles[t]; %>
+				<div class="tile"
+					data-id="<%= tile.id %>"
+					id="<%= tile.id %>"
+					tabindex=0
+					role="listitem">
+				<%= tile.name %>
+					<button class="clue" data-id="<%= tile.id %>" tabindex="-1"></button>
+				</div>
+			<% } %>
+			<div id="tileFiller"></div>
+		</div>
+		<section id="tileSection"></section>
+		<aside id="numberBar" class="nondraggable">
+			<div class="numbers">1</div>
+		</aside>
+		<section id="orderArea">
+			<div id="orderInstructions">Drag and organize tiles here</div>
+		</section>
+		<div id="submitHolder" class="nondraggable">
+			<button id="submit" class="big-button nondraggable" disabled="true">Submit Sequence</button>
+		</div>
+		<button id="wraparound"
+			class="visible-on-focus big-button nondraggable"
+			role="button"
+			tabindex=0>
+			Select First Unsorted Item
+		</button>
+		<footer id="score-area">
+			<h4 id="score-text">Score: <span id="score"><%= score %></span></h4>
+			<h5><span id="practiceMode-info">(Practice Mode)</span></h5>
+			<h5><span id="attempts-info">(<span id="attemptsLeft"><%= freeAttempts %></span> guesses left)</span></h5>
+		</footer>
+	</div>
 </script>
 
 <!-- clues -->
@@ -79,37 +128,6 @@
 <script type="text/template" id="message-window"><div class="nondraggable" id="message">
 		<h2><%= title %></h2>
 		<p><%= messageText %></p>
-	</div>
-</script>
-
-<!-- message window (Tutorial) -->
-<script type="text/template" id="demo-window"><div id="demo">
-		<div id="popupWindowHeader">
-			<h3>Sequencer!</h3>
-			<h4>Put em in order</h4>
-		</div>
-		<div id="demoArea">
-			<div id="demoTitle"><%= demoTitle %></div>
-			<div id="demoFooter"></div>
-			<div class="demoTile move" id="dt1">1</div>
-			<div class="demoTile move" id="dt2">2</div>
-			<div class="demoTile move" id="dt3">3</div>
-			<div id="demoTileSection"></div>
-			<div id="demoOrderArea"></div>
-			<div id="demoNumberBar"></div>
-			<div id="demoSubmitButton" class="hover">Submit</div>
-			<div id="demoMouse"><img src="assets/cursor.svg"></div>
-			<div id="demoFinish" class="show">Score:
-				<div id="demoScore">100%</div>
-			</div>
-			<div id="playInstructions">
-				<h3>How to play:</h3>
-				<p>Order the tiles correctly in the sequence list.</p>
-				<p>You have <span class="demoDeduction"><%= freeAttempts %> guesses</span>.</p>
-				<p>Your highest score will be saved.</p>
-			</div>
-			<button class="demoButton">Play Sequencer</button>
-		</div>
 	</div>
 </script>
 
@@ -175,12 +193,12 @@
 	</section>
 </script>
 
-<div class="confirmDialog">
+<div class="confirmDialog" inert="true">
 	<p>
 		Are you sure you want to stop with your best score of <span class="bestscore bold"></span>?
 	</p>
-	<button id="cancelBestScoreButton" class="resultsButton" tabindex="-1">No, keep trying</button>
-	<button id="confirmBestScoreButton" class="resultsButton" tabindex="-1">Yes, finish with <span class="bestscore"></span>.</button>
+	<button id="cancelBestScoreButton" class="resultsButton">No, keep trying</button>
+	<button id="confirmBestScoreButton" class="resultsButton">Yes, finish with <span class="bestscore"></span>.</button>
 </div>
 
 <div role="status" class="ariaLiveStatus" aria-live="polite"></div>

--- a/src/player.scss
+++ b/src/player.scss
@@ -981,6 +981,25 @@ header {
 	}
 }
 
+#keyboard-instructions-window {
+	display: none;
+	position: absolute;
+	box-sizing: border-box;
+	left: 40px;
+	top: 90px;
+	width: 670px;
+	height: 380px;
+	background: $lblurple;
+	padding: 0 20px;
+	z-index: 150;
+	border-radius: 10px;
+	box-shadow: 0px 0px 10px 10px rgba(0,0,0,.1);
+
+	.big-button {
+		padding: 0 30px;
+	}
+}
+
 #demo {
 	position: absolute;
 	left: 50px;

--- a/src/player.scss
+++ b/src/player.scss
@@ -263,6 +263,10 @@ header {
 	border-radius: 5px;
 	box-shadow: 0 4px 3px -3px black;
 
+	&:focus {
+		border: solid 2px #4F7CBE;
+	}
+
 	@include boxSizing();
 
 	.clue {
@@ -273,6 +277,8 @@ header {
 		background: url("assets/Clue_fade.png") 0 0;
 		height: 22px;
 		width: 16px;
+
+		border: none;
 
 		&:hover {
 			background: url("assets/Clue_glow.png") 0 0;
@@ -404,10 +410,11 @@ header {
 		position: absolute;
 		cursor: auto;
 		width: 90%;
-		height: 25px;
+		height: 35px;
 		left: 5%;
 		top: 5px;
-		padding: 5px 0px 2px 0px;
+		padding: 3px 0px 2px 0px;
+		font-family: 'AmericanTypewriter';
 		font-size:18px;
 		text-align: center;
 		color: $medgrey;
@@ -420,8 +427,7 @@ header {
 		background:	linear-gradient(top, $light, $grey);
 		border: 1px solid $medgrey;
 		border-radius: 10px;
-		box-shadow: inset 0 3px 0 rgba(255,255,255,0.5);
-		transition: all 300ms ease;
+		transition: all 25ms ease;
 		pointer-events: none;
 		&.enabled {
 			cursor: pointer;
@@ -434,12 +440,17 @@ header {
 			background:	linear-gradient(bottom, $light, $grey);
 			border: 1px solid $medgrey;
 			border-radius: 10px;
-			box-shadow: inset 0 3px 0 rgba(255,255,255,0.5), 0px 0px 2px 2px rgba(0,0,0,0.05);
-			transition: all 300ms ease;
+			transition: all 25ms ease;
 			pointer-events: all;
 			&:hover {
-				background:	linear-gradient(bottom, $light, $light);
+				background:	$medblue;
 			}
+		}
+
+		&:focus {
+			border: solid 2px #4F7CBE;
+			color: #fff;
+			background: $blue;
 		}
 	}
 }
@@ -535,6 +546,8 @@ header {
 	border-radius: 10px;
 	box-shadow: 0px 0px 10px 10px rgba(0,0,0,.1);
 
+	text-align: center;
+
 	#resultsInner {
 		position: absolute;
 		width: 220px;
@@ -547,6 +560,8 @@ header {
 		border-radius: 10px;
 		box-shadow: 0px 0px 20px 20px rgba(0,0,0,.1) inset;
 		transition: 100ms;
+
+		text-align: left;
 
 
 		#textBelowNumbers {
@@ -775,8 +790,9 @@ header {
 
 	#resultsBox {
 		position: absolute;
+		// left: -10px;
 		bottom: 15px;
-		width: 100%;
+		width: calc(100% - 20px);
 		color: #fff;
 		font-family: sans-serif;
 
@@ -870,19 +886,34 @@ header {
 		}
 
 		#submitScoreButton {
+			// position: relative;
+			// left: -10px;
+			margin-left: auto;
+			margin-right: auto;
+			padding: 5px 10px;
+
+			opacity: 0;
+			background: none;
+			border: none;
+
 		    color: #fff;
 		    text-decoration: underline;
-		    cursor: pointer;
 		    text-align: center;
-		    position: relative;
-		    left: -10px;
-		    opacity: 0;
-		    transform: scale(0.7);
+			
+		    cursor: pointer;
+		    // transform: scale(0.7);
+
 		    &.show {
 			    opacity: 1;
 			    transform: scale(1);
-			    transition: 300ms;
-			    transition-delay: 1s;
+			    // transition: 300ms;
+			    // transition-delay: 1s;
+
+				&:focus {
+					border: solid 2px $medblue;
+				}
+
+				
 		    }
 		}
 	}
@@ -1129,10 +1160,10 @@ header {
 			position: absolute;
 			right: 30px;
 			bottom: 10px;
-			height: 25px;
+			height: 35px;
 			width: 180px;
 			margin: 25px 5px 0px 20px;
-			padding: 5px 3px 0px 3px;
+			padding: 5px 3px 5px 3px;
 			text-align: center;
 			color: $red;
 			z-index: 300;
@@ -1143,8 +1174,10 @@ header {
 			background-image: -ms-linear-gradient(top, $light, $grey);
 			background-image: -o-linear-gradient(top, $light, $grey);
 			background-image: linear-gradient(top, $light, $grey);
+			border-width: 1px;
 		 	border-radius: 10px;
-			transition: 200ms 1s;
+			font-family: 'AmericanTypewriter';
+			font-size: 16px;
 
 			&:hover {
 				background:	linear-gradient(bottom, $light, $light);
@@ -1154,8 +1187,10 @@ header {
 				pointer-events: auto;
 				cursor: pointer;
 				opacity: 1;
-				transition: 200ms 500ms;
-				animation: zoomBounce 300ms ease-out 500ms;
+			}
+
+			&:focus {
+				border: solid 3px $titleblue;
 			}
 		}
 	}
@@ -1293,11 +1328,15 @@ header {
     left: 59px;
     bottom: 30px;
     pointer-events: none;
+	border: solid 3px #fff;
+
     &.show {
-	pointer-events: auto;
-	opacity: 1;
-	animation: zoomBounce 300ms ease-out 300ms;
-	transition: 200ms 300ms;
+		pointer-events: auto;
+		opacity: 1;
+
+		&:focus {
+			border: solid 3px $medblue;
+		}
     }
 
 }
@@ -1305,7 +1344,7 @@ header {
     max-width: 200px;
     min-width: 155px;
     margin: 25px 5px 5px 20px;
-    padding: 8px 5px 5px 5px;
+    padding: 6px 5px 5px 6px;
     font-weight: bold;
     text-align: center;
     color: $red;
@@ -1320,9 +1359,15 @@ header {
     border-radius: 10px;
     cursor: pointer;
 
+	border: solid 3px #fff;
+
     &:hover {
 	background:	linear-gradient(bottom, $light, $light);
     }
+
+	&:focus {
+		border: solid 3px $medblue;
+	}
 
     div {
 	font-size: 12px;
@@ -1358,4 +1403,12 @@ header {
 
 .bestscore.bold {
     font-weight: bold;
+}
+
+.ariaLiveAlert, .ariaLiveStatus {
+	display: inline-block;
+	position: absolute;
+	left: -999;
+	z-index: -999;
+	opacity: 0;
 }

--- a/src/player.scss
+++ b/src/player.scss
@@ -46,6 +46,17 @@ $hblurple: #73839B;
 	font-weight: normal;
 }
 
+@font-face {
+	font-family: 'icomoon';
+	src:url('assets/font/icomoon.eot?hqw8tf');
+	src:url('assets/font/icomoon.eot?#iefixhqw8tf') format('embedded-opentype'),
+		url('assets/font/icomoon.woff?hqw8tf') format('woff'),
+		url('assets/font/icomoon.ttf?hqw8tf') format('truetype'),
+		url('assets/font/icomoon.svg?hqw8tf#icomoon') format('svg');
+	font-weight: normal;
+	font-style: normal;
+}
+
 html, body {
 	overflow-x: hidden;
 	overflow-y: hidden;
@@ -130,6 +141,77 @@ header {
 	}
 }
 
+#keyboard-instructions {
+	top: 3px;
+	right: 15px;
+	width: 240px;
+	z-index: 5;
+	font-size:16px;
+}
+
+#wraparound.visible-on-focus {
+	position: absolute;
+	bottom: 30px;
+	left: 55px;
+}
+.visible-on-focus {
+	opacity: 0;
+	height: 0;
+	width: 0;
+	pointer-events: none;
+
+	&:focus {
+		opacity: 1;
+		width: 50%;
+		height: auto;
+	}
+}
+.big-button {
+	position: absolute;
+	cursor: auto;
+	padding: 3px 0px 2px 0px;
+	font-family: 'AmericanTypewriter';
+	font-size:18px;
+	text-align: center;
+	color: $medgrey;
+	z-index: 300;
+	background: $light;
+	background: -webkit-linear-gradient(to bottom, $light, $grey);
+	background: -moz-linear-gradient(to bottom, $light, $grey);
+	background: -ms-linear-gradient(to bottom, $light, $grey);
+	background: -o-linear-gradient(to bottom, $light, $grey);
+	background:	linear-gradient(to bottom, $light, $grey);
+	border: 1px solid $medgrey;
+	border-radius: 10px;
+	transition: all 25ms ease;
+	pointer-events: none;
+
+	&.enabled {
+		cursor: pointer;
+		color: $blue;
+		background: $light;
+		background: -webkit-linear-gradient(to top, $light, $grey);
+		background: -moz-linear-gradient(to top, $light, $grey);
+		background: -ms-linear-gradient(to top, $light, $grey);
+		background: -o-linear-gradient(to top, $light, $grey);
+		background:	linear-gradient(to top, $light, $grey);
+		border: 1px solid $medgrey;
+		border-radius: 10px;
+		transition: all 25ms ease;
+		pointer-events: all;
+
+		&:hover {
+			background:	$medblue;
+		}
+	}
+
+	&:focus {
+		border: solid 2px #4F7CBE;
+		color: #fff;
+		background: $blue;
+	}
+}
+
 #clueHeader {
 	position: absolute;
 	z-index: 15;
@@ -190,7 +272,7 @@ header {
 #dragContainer {
 	position: absolute;
 	width: 100%;
-	top: 11px;
+	top: 31px;
 	bottom: 58px;
 	padding: 0px 0px 0px 0px;
 	overflow: auto;
@@ -206,12 +288,12 @@ header {
 	margin-bottom: 15px;
 	padding: 15px 15px 15px 15px;
 	background: url("assets/panel_bg.png") 0 0;
-    border-radius: 10px;
+	border-radius: 10px;
 	box-shadow: inset 0px 0px 10px -10px #000000;
 	transition: 200ms;
 	z-index: 9;
 
-     &:before{
+	&:before{
 		content: "";
 		position: absolute;
 		width: 100%;
@@ -292,8 +374,8 @@ header {
 	position: absolute;
 	width: 50px;
 	right: 205px;
-	top: 10px;
-	height: 480px;
+	top: 30px;
+	height: 460px;
 	background: $blurple;
 	overflow: hidden;
 	z-index: 5;
@@ -319,28 +401,28 @@ header {
 		font-family: sans-serif;
 		border-radius: 50%;
 
-        &.show {
-        	opacity: 1;
-        	transition: 100ms ease;
-        }
+		&.show {
+			opacity: 1;
+			transition: 100ms ease;
+		}
 
-	    &.highlight {
-	    	background: $hblurple;
-	    	color: $blurple;
-	    	transition: 100ms ease;
-	    }
-	    &.green{
-	    	background: green;
-	    }
+		&.highlight {
+			background: $hblurple;
+			color: $blurple;
+			transition: 100ms ease;
+		}
+		&.green{
+			background: green;
+		}
 	}
 }
 
 #orderArea {
 	position: absolute;
-	top: 10px;
+	top: 30px;
 	right: 0px;
 	width: 190px;
-	height: 480px;
+	height: 460px;
 	margin-right: 15px;
 	margin-left: 10px;
 	background: $lblurple;
@@ -407,51 +489,10 @@ header {
 	border-radius: 0px 0px 10px 10px;
 
 	#submit {
-		position: absolute;
-		cursor: auto;
 		width: 90%;
 		height: 35px;
 		left: 5%;
 		top: 5px;
-		padding: 3px 0px 2px 0px;
-		font-family: 'AmericanTypewriter';
-		font-size:18px;
-		text-align: center;
-		color: $medgrey;
-		z-index: 300;
-		background: $light;
-		background: -webkit-linear-gradient(top, $light, $grey);
-		background: -moz-linear-gradient(top, $light, $grey);
-		background: -ms-linear-gradient(top, $light, $grey);
-		background: -o-linear-gradient(top, $light, $grey);
-		background:	linear-gradient(top, $light, $grey);
-		border: 1px solid $medgrey;
-		border-radius: 10px;
-		transition: all 25ms ease;
-		pointer-events: none;
-		&.enabled {
-			cursor: pointer;
-			color: $blue;
-			background: $light;
-			background: -webkit-linear-gradient(bottom, $light, $grey);
-			background: -moz-linear-gradient(bottom, $light, $grey);
-			background: -ms-linear-gradient(bottom, $light, $grey);
-			background: -o-linear-gradient(bottom, $light, $grey);
-			background:	linear-gradient(bottom, $light, $grey);
-			border: 1px solid $medgrey;
-			border-radius: 10px;
-			transition: all 25ms ease;
-			pointer-events: all;
-			&:hover {
-				background:	$medblue;
-			}
-		}
-
-		&:focus {
-			border: solid 2px #4F7CBE;
-			color: #fff;
-			background: $blue;
-		}
 	}
 }
 
@@ -896,25 +937,23 @@ header {
 			background: none;
 			border: none;
 
-		    color: #fff;
-		    text-decoration: underline;
-		    text-align: center;
-			
-		    cursor: pointer;
-		    // transform: scale(0.7);
+			color: #fff;
+			text-decoration: underline;
+			text-align: center;
 
-		    &.show {
-			    opacity: 1;
-			    transform: scale(1);
-			    // transition: 300ms;
-			    // transition-delay: 1s;
+			cursor: pointer;
+			// transform: scale(0.7);
+
+			&.show {
+				opacity: 1;
+				transform: scale(1);
+				// transition: 300ms;
+				// transition-delay: 1s;
 
 				&:focus {
 					border: solid 2px $medblue;
 				}
-
-				
-		    }
+			}
 		}
 	}
 }
@@ -933,7 +972,7 @@ header {
 	border: 1px solid $dgrey;
 	opacity: 0;
 	box-shadow: 0px 8px -6px black;
- 	border-radius: 10px;
+	border-radius: 10px;
 	transition: 100ms;
 
 	&.show {
@@ -951,7 +990,7 @@ header {
 	background: $titleblue;
 	z-index: 150;
 	border-radius: 10px;
-   	box-shadow: 0px 0px 10px 10px rgba(0,0,0,.1);
+	box-shadow: 0px 0px 10px 10px rgba(0,0,0,.1);
 
 	#demoArea {
 		position: absolute;
@@ -964,7 +1003,7 @@ header {
 		background-repeat: no-repeat;
 		z-index: 150;
 		border-radius: 10px;
-	   	box-shadow: 0px 0px 20px 20px rgba(0,0,0,.1) inset;
+		box-shadow: 0px 0px 20px 20px rgba(0,0,0,.1) inset;
 
 		#demoTileSection {
 			position: absolute;
@@ -1039,8 +1078,8 @@ header {
 			z-index: 301;
 			animation: demoMouseMovement 10000ms ease-out 300ms infinite;
 			img {
-			    width: 25px;
-			    height: 25px;
+				width: 25px;
+				height: 25px;
 			}
 		}
 
@@ -1073,7 +1112,7 @@ header {
 			padding-top: 5px;
 			z-index: 301;
 			border-radius: 3px;
-		    box-shadow: 0px 0px 3px 3px rgba(0,0,0,.05);
+			box-shadow: 0px 0px 3px 3px rgba(0,0,0,.05);
 		}
 
 		#dt1 {
@@ -1169,18 +1208,18 @@ header {
 			z-index: 300;
 			background: $light;
 			opacity: 0;
-			background-image: -webkit-linear-gradient(top, $light, $grey);
-			background-image: -moz-linear-gradient(top, $light, $grey);
-			background-image: -ms-linear-gradient(top, $light, $grey);
-			background-image: -o-linear-gradient(top, $light, $grey);
-			background-image: linear-gradient(top, $light, $grey);
+			background-image: -webkit-linear-gradient(to bottom, $light, $grey);
+			background-image: -moz-linear-gradient(to bottom, $light, $grey);
+			background-image: -ms-linear-gradient(to bottom, $light, $grey);
+			background-image: -o-linear-gradient(to bottom, $light, $grey);
+			background-image: linear-gradient(to bottom, $light, $grey);
 			border-width: 1px;
-		 	border-radius: 10px;
+			border-radius: 10px;
 			font-family: 'AmericanTypewriter';
 			font-size: 16px;
 
 			&:hover {
-				background:	linear-gradient(bottom, $light, $light);
+				background:	linear-gradient(to top, $light, $light);
 			}
 
 			&.show {
@@ -1191,6 +1230,7 @@ header {
 
 			&:focus {
 				border: solid 3px $titleblue;
+				background:	linear-gradient(to top, $light, $light);
 			}
 		}
 	}
@@ -1312,97 +1352,97 @@ header {
 
 /*
 .circle {
-    opacity: 1;
-    background: $light;
-    color: $red;
-    height: 25px;
-    width: 25px;
-    padding: 2px;
-    border-radius: 50%;
+	opacity: 1;
+	background: $light;
+	color: $red;
+	height: 25px;
+	width: 25px;
+	padding: 2px;
+	border-radius: 50%;
 }
 */
 
 #resultsButton {
-    position: absolute;
-    opacity: 0;
-    left: 59px;
-    bottom: 30px;
-    pointer-events: none;
+	position: absolute;
+	opacity: 0;
+	left: 59px;
+	bottom: 30px;
+	pointer-events: none;
 	border: solid 3px #fff;
 
-    &.show {
+	&.show {
 		pointer-events: auto;
 		opacity: 1;
 
 		&:focus {
 			border: solid 3px $medblue;
 		}
-    }
+	}
 
 }
 .resultsButton {
-    max-width: 200px;
-    min-width: 155px;
-    margin: 25px 5px 5px 20px;
-    padding: 6px 5px 5px 6px;
-    font-weight: bold;
-    text-align: center;
-    color: $red;
-    z-index: 300;
-    background: $light;
-    background: #fff;
-    background: -webkit-linear-gradient(top, $light, $grey);
-    background: -moz-linear-gradient(top, $light, $grey);
-    background: -ms-linear-gradient(top, $light, $grey);
-    background: -o-linear-gradient(top, $light, $grey);
-    background:	linear-gradient(top, $light, $grey);
-    border-radius: 10px;
-    cursor: pointer;
+	max-width: 200px;
+	min-width: 155px;
+	margin: 25px 5px 5px 20px;
+	padding: 6px 5px 5px 6px;
+	font-weight: bold;
+	text-align: center;
+	color: $red;
+	z-index: 300;
+	background: $light;
+	background: #fff;
+	background: -webkit-linear-gradient(top, $light, $grey);
+	background: -moz-linear-gradient(top, $light, $grey);
+	background: -ms-linear-gradient(top, $light, $grey);
+	background: -o-linear-gradient(top, $light, $grey);
+	background:	linear-gradient(top, $light, $grey);
+	border-radius: 10px;
+	cursor: pointer;
 
 	border: solid 3px #fff;
 
-    &:hover {
+	&:hover {
 	background:	linear-gradient(bottom, $light, $light);
-    }
+	}
 
 	&:focus {
 		border: solid 3px $medblue;
 	}
 
-    div {
+	div {
 	font-size: 12px;
-    }
+	}
 }
 
 .confirmDialog {
-    z-index: -1;
-    opacity: 0;
-    background: $titleblue;
-    position: absolute;
-    transition: all 0.2s ease;
-    -webkit-transform: scale(0.7);
+	z-index: -1;
+	opacity: 0;
+	background: $titleblue;
+	position: absolute;
+	transition: all 0.2s ease;
+	-webkit-transform: scale(0.7);
 
-    font-family: arial;
+	font-family: arial;
 
-    color: #fff;
+	color: #fff;
 
-    text-align: center;
+	text-align: center;
 
-    top: 180px;
-    left: 100px;
-    padding: 10px 40px 20px 30px;
-    width: 230px;
-    border-radius: 5px;
+	top: 180px;
+	left: 100px;
+	padding: 10px 40px 20px 30px;
+	width: 230px;
+	border-radius: 5px;
 
-    &.show {
+	&.show {
 	opacity: 1;
 	z-index: 10000;
 	-webkit-transform: scale(1);
-    }
+	}
 }
 
 .bestscore.bold {
-    font-weight: bold;
+	font-weight: bold;
 }
 
 .ariaLiveAlert, .ariaLiveStatus {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,7 +4371,7 @@ next-tick@^1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-"ngmodal@github:ucfcdl/ngModal#v1.2.2":
+ngmodal@ucfcdl/ngModal#v1.2.2:
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1067,6 +1072,15 @@ binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 block-stream@*:
   version "0.0.9"
@@ -1260,6 +1274,14 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -1422,6 +1444,11 @@ chownr@^1.0.1, chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
   integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
 
+chownr@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -1531,7 +1558,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.3.0, color-convert@^1.9.0:
+color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1555,6 +1582,14 @@ color-string@^0.3.0:
   dependencies:
     color-name "^1.0.0"
 
+color-string@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
+  integrity sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@^0.11.0:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
@@ -1563,6 +1598,14 @@ color@^0.11.0:
     clone "^1.0.2"
     color-convert "^1.3.0"
     color-string "^0.3.0"
+
+color@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colormin@^1.0.5:
   version "1.1.2"
@@ -1987,6 +2030,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -2084,7 +2134,7 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -2233,6 +2283,13 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
+end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
@@ -2468,6 +2525,11 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 express@^4.16.0, express@^4.16.2:
   version "4.17.1"
@@ -2746,12 +2808,24 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
   integrity sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==
   dependencies:
     minipass "^2.2.1"
+
+fs-minipass@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -2838,6 +2912,11 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -3201,6 +3280,11 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -3261,7 +3345,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3338,6 +3422,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -3903,19 +3992,19 @@ marked@^0.6.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.3.tgz#79babad78af638ba4d522a9e715cdfdd2429e946"
   integrity sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==
 
-materia-server-client-assets@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/materia-server-client-assets/-/materia-server-client-assets-2.0.0.tgz#341df286e4e4611e9fa9da943e2e76e0adb8d3b4"
-  integrity sha512-Mfg5cfSHMb3R0yOgsem+m87gc96+cJ/iQyADiopQmf3+nvhejthJx9fdja/lVw4BunXESRHDy41+SMyWtwaMiw==
+materia-server-client-assets@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/materia-server-client-assets/-/materia-server-client-assets-2.1.0.tgz#8e10383296804fab2b7c2b25358ede26e9e9024c"
+  integrity sha512-osOIJ7xlf5cQJwOxA6JUD499gs3arjDTB7vKTUM68icg6gDq+kmhfFGE+XcBFQuoI/HTcqN9JR/TsA+Z5n5Rqg==
   dependencies:
     angular "1.6.9"
     js-snakecase "^1.2.0"
     ngmodal ucfcdl/ngModal#v1.2.2
 
-materia-widget-development-kit@2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-2.4.2.tgz#e45ff8125f6f67f0ebb874037d06a68985095cbd"
-  integrity sha512-uyDNv8xhwxeyDxQGSj0DmJ5Q9TpnfMylETMd1gBG9Ag+Fq9CLv9ELjWKXlZQGHy7X3UdVmrBiornBzsWilSC8w==
+materia-widget-development-kit@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-2.5.2.tgz#831c7852bf2021cce8ed80a2b92d6153532b92f3"
+  integrity sha512-rth0CHtNm1R+5f1poDjHpx5iGzPTw9PjBexlp8KoBr/NaOFEPP8SCxZtBq2YltwRUcH3MOukLoa4k+566uTRXQ==
   dependencies:
     "@babel/core" "^7.4.5"
     "@babel/preset-env" "^7.4.5"
@@ -3937,12 +4026,13 @@ materia-widget-development-kit@2.4.2:
     html-loader "^0.5.5"
     html-webpack-plugin "^2.29.0"
     markdown-loader "^5.0.0"
-    materia-server-client-assets "2.0.0"
+    materia-server-client-assets "2.1.0"
     node-sass "^4.12.0"
     postcss-loader "2.0.6"
     prettier "^1.11.1"
     raw-loader "^0.5.1"
     sass-loader "^6.0.6"
+    sharp "^0.23.0"
     string-replace-loader "^1.3.0"
     style-loader "^0.20.2"
     wait-until-promise "^1.0.0"
@@ -4062,6 +4152,11 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -4089,6 +4184,11 @@ minimist@^1.1.3, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.3, minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minipass@^2.2.1, minipass@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
@@ -4097,12 +4197,27 @@ minipass@^2.2.1, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^3.0.0, minipass@^3.1.3:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
+  integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
+
+minizlib@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^2.0.0:
   version "2.0.0"
@@ -4136,6 +4251,11 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
@@ -4147,6 +4267,13 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -4193,6 +4320,11 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nan@^2.14.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4209,6 +4341,11 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
 
 needle@^2.2.1:
   version "2.4.0"
@@ -4234,7 +4371,7 @@ next-tick@^1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-ngmodal@ucfcdl/ngModal#v1.2.2:
+"ngmodal@github:ucfcdl/ngModal#v1.2.2":
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 
@@ -4244,6 +4381,13 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-abi@^2.7.0:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
+  integrity sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
+  dependencies:
+    semver "^5.4.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -4343,6 +4487,11 @@ node-sass@^4.12.0:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
+
 nopt@1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
@@ -4422,7 +4571,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5133,6 +5282,27 @@ postcss@^6.0.1, postcss@^6.0.17, postcss@^6.0.2:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+prebuild-install@^5.3.3:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
+  integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.7.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
 prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -5210,6 +5380,14 @@ pump@^2.0.0, pump@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
   integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -5372,6 +5550,15 @@ readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -5742,6 +5929,11 @@ semver@^6.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
   integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
 
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -5841,6 +6033,21 @@ shallow-clone@^1.0.0:
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
+sharp@^0.23.0:
+  version "0.23.4"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.23.4.tgz#ca36067cb6ff7067fa6c77b01651cb9a890f8eb3"
+  integrity sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==
+  dependencies:
+    color "^3.1.2"
+    detect-libc "^1.0.3"
+    nan "^2.14.0"
+    npmlog "^4.1.2"
+    prebuild-install "^5.3.3"
+    semver "^6.3.0"
+    simple-get "^3.1.0"
+    tar "^5.0.5"
+    tunnel-agent "^0.6.0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -5858,10 +6065,31 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^3.0.3, simple-get@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
+  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
+  dependencies:
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 simple-is@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/simple-is/-/simple-is-0.2.0.tgz#2abb75aade39deb5cc815ce10e6191164850baf0"
   integrity sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6237,6 +6465,27 @@ tapable@^0.2.7:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.9.tgz#af2d8bbc9b04f74ee17af2b4d9048f807acd18a8"
   integrity sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==
 
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
@@ -6258,6 +6507,18 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+tar@^5.0.5:
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-5.0.11.tgz#f6e972e26960f71387c88e4313b202889be09292"
+  integrity sha512-E6q48d5y4XSCD+Xmwc0yc8lXuyDK38E0FB8N4S/drQRtXOMUhfhDxbB0xr2KKDhNfO51CFmoa6Oz00nAkWsjnA==
+  dependencies:
+    chownr "^1.1.4"
+    fs-minipass "^2.1.0"
+    minipass "^3.1.3"
+    minizlib "^2.1.2"
+    mkdirp "^0.5.5"
+    yallist "^4.0.0"
 
 through2@^2.0.0:
   version "2.0.5"
@@ -6747,6 +7008,11 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
+
 which@1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -6808,6 +7074,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yamljs@^0.2.8:
   version "0.2.10"


### PR DESCRIPTION
So far:
- Added rudimentary keyboard support to the player. Use `tab` or `shift + tab` to navigate the list of tiles, `right arrow` to sort, `left arrow` to unsort, and `up` or `down` arrows to move sorted tiles up or down through the list. `Enter/return` to view the clue for a tile, if it exists. 
- Improved tab indexes and added auto-focus behavior to the sequence submission and "Are you sure?" dialogs.
- Improved focus and hover styles for certain buttons.
- Added some basic aria-live regions, including tile clues and notifications of certain user actions including tile sorting.

However, it's clear there's more work that needs to be done, particularly with keyboard navigation of the tile list and screen-reader navigation:
- Tabbing through the list of tiles remains unintuitive, because tab indexes are randomly shuffled when the tiles are placed. The tiles, when placed in the sorted list, do not change the tab order, which can be confusing.
- There are no aria-live updates to indicate a tile's position in the list, unless the ordering is modified with `up` or `down arrow`. 

Some ideas:
- Split the unsorted and sorted regions into two different list, within which the tiles can be selected via arrow keys or some other means.
- Tiles placed into the sorted section should have a coherent tab order based on their position in the list.
- Since arrow keys are likely to be used for tile navigation, we'll need to change the shortcuts for actually rearranging tiles in the sorted list.
- Confirm that the aria roles for the tile regions should be `list`, and if not, investigate a better role to assign to these.
